### PR TITLE
🐛 FIX: URL detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .env
 database/*
 package-lock.json
+.idea/
+yarn.lock

--- a/src/commands/techWatch/createLink.js
+++ b/src/commands/techWatch/createLink.js
@@ -4,7 +4,7 @@ const { urlRegexp } = require('../../helpers/string.helper')
 
 async function createLink(message, link, city) {
   try {
-    if (!link.match(urlRegexp)) {
+    if (!link || !link.match(urlRegexp)) {
       throw new Error('Please send a real url')
     }
     const linkCount = await db.link.count({


### PR DESCRIPTION
Just adding a very simple condition to avoid the error `Cannot read property 'match' of undefined` that is sent when the command `!techwatch add` is ran without any link.
Also edited `.gitignore` to ignore `.idea` ([Jetbrains](https://www.jetbrains.com/) files) and [yarn](https://yarnpkg.com) files